### PR TITLE
Fix Address field null value in GET methods Response Body

### DIFF
--- a/TechCare/Controller/Patient/PatientController.cs
+++ b/TechCare/Controller/Patient/PatientController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using TechCare.Data;
 using TechCare.Models.Patient;
 
@@ -15,13 +16,18 @@ namespace TechCare.Controller.Patient
         [HttpGet]
         public IList<PatientModel> GetAll()
         {
-            return _context.Patients.ToList();
+            return _context.Patients
+                .Include(patient => patient.Address)
+                .ToList();
         }
 
         [HttpGet("{id}")]
         public IActionResult GetPatientById(long id) 
         {
-            var patient = _context.Patients.FirstOrDefault(patient => patient.Id == id);
+            var patient = _context.Patients
+                .Include(patient => patient.Address)
+                .FirstOrDefault(patient => patient.Id == id);
+
             return (patient == null) ? NotFound() : Ok(patient);
         }
 


### PR DESCRIPTION
### The problem
All GET methods return the patient's address data as `null`, when it should return the correct fields.

### How to fix it
By default, EntityFramework Core uses a lazy loading strategy, meaning it will load only explicitly requested data.

When we call `_context.FirstOrDefault`, we are only requesting the context model's data.
Since `AddressModel` is another entity, with its own database table generated by the migrations, we need to tell EF to query it from the database along with its associated `PatientModel`.

This Pull Request adds the `Include` method calls, which tells EFCore to query address data.

#### Example
- Original code:
```csharp
_context.Patients.ToList();
```
- Updated code:
```csharp
using Microfost.EntityFrameworkCore;

_context.Patients.Include(p => p.Address).ToList();
```